### PR TITLE
Switch to VLC's TCP interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var VLCPlayer = require('./vlc');
 var tube = require('./tube');
 var SYNC_ACCURACY = 2;
 
-var vlc = new VLCPlayer();
+var vlc = new VLCPlayer(process.argv[2], process.argv[3]);
 
 tube.onVideoChange(function (link, time) {
     vlc.load(link);


### PR DESCRIPTION
VLC's TCP interface also works on Windows. Also adds the ability to give
the location of the VLC executable as a command line parameter, and
checks a few default locations on Windows.

`VLCPlayer`'s constructor's `link` argument appeared unused, so I replaced it with arguments to define the location of the VLC executable and the port to use for communicating with it.
